### PR TITLE
add urls to _pkgdown and description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Authors@R: c(
 Description: Tools to evaluate and design Global Statistical Tests (GST). The package also provides a GUI to draw forestplot of multiple endpoints.
 License: file LICENSE
 URL: https://sarepta-therapeutics.github.io/gst, https://github.com/Sarepta-Therapeutics/gst/
+BugReports: https://github.com/Sarepta-Therapeutics/gst/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,9 +14,10 @@ Authors@R: c(
     )
 Description: Tools to evaluate and design Global Statistical Tests (GST). The package also provides a GUI to draw forestplot of multiple endpoints.
 License: file LICENSE
+URL: https://sarepta-therapeutics.github.io/gst, https://github.com/Sarepta-Therapeutics/gst/
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     dplyr,
     forestploter,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: ~
+url: https://sarepta-therapeutics.github.io/gst
 template:
   bootstrap: 5
 


### PR DESCRIPTION
This is not related to the actual github pages deployment. I did that deployment manually with a quick deploy_to_branch() that we can replace with github actions later. This PR is just about maintaining documentation that I knocked out while waiting on the manual deploy. 